### PR TITLE
Remove static from EncodeSpecialTimestamp

### DIFF
--- a/timestampandtz.c
+++ b/timestampandtz.c
@@ -69,7 +69,7 @@ static void debug_tm(struct pg_tm *tm)
 		tm->tm_hour, tm->tm_min, tm->tm_sec);
 }
 
-static void EncodeSpecialTimestamp(Timestamp dt, char *str)
+void EncodeSpecialTimestamp(Timestamp dt, char *str)
 {
     if (TIMESTAMP_IS_NOBEGIN(dt))
         strcpy(str, EARLY);


### PR DESCRIPTION
timestampandtz.c:72:13: error: static declaration of ‘EncodeSpecialTimestamp’ follows non-static declaration
 static void EncodeSpecialTimestamp(Timestamp dt, char *str)
             ^
In file included from timestampandtz.c:9:0:
/usr/include/postgresql/9.6/server/utils/datetime.h:329:13: note: previous declaration of ‘EncodeSpecialTimestamp’ was here
 extern void EncodeSpecialTimestamp(Timestamp dt, char *str);